### PR TITLE
feat(dom): add keyboard commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ get focusedElement(): Element
 ```
 
 ```typescript
+get isKeyboardShown(): boolean
+```
+
+```typescript
 render(): Promise<void>
 ```
 
@@ -390,6 +394,14 @@ get isDisplayed(): boolean
 
 ```typescript
 isSameNode(element: Element): boolean
+```
+
+```typescript
+clear(): Promise<void>
+```
+
+```typescript
+type(text: string): Promise<void>
 ```
 
 ```typescript

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -19,6 +19,30 @@ export class Document extends Element {
     return this.cssSelect('[focused="true"]:not(:has([focused="true"]))') || this;
   }
 
+  get isKeyboardShown(): boolean {
+    return this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]')?.isDisplayed || false;
+  }
+
+  async clear() {
+    const keyboard = this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+
+    if (keyboard) {
+      await keyboard.clear();
+    } else {
+      throw new RokuError('Keyboard must be visible to clear the field');
+    }
+  }
+
+  async type(text: string) {
+    const keyboard = this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+
+    if (keyboard) {
+      await keyboard.type(text);
+    } else {
+      await this.sdk.ecp.type(text);
+    }
+  }
+
   async render() {
     let xml;
 

--- a/src/Element.ts
+++ b/src/Element.ts
@@ -157,6 +157,107 @@ export class Element {
     return this === element || this.node === element.node || this.path === element.path;
   }
 
+  async clear() {
+    // If the element is inside the keyboard,
+    // make sure the keyboard is activated
+    // and clear the text with `Backspace`
+
+    let keyboard = this.xpathSelect('./ancestor-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+
+    if (keyboard) {
+      await keyboard.focus();
+
+      const input = keyboard.xpathSelect('.//*[@text]');
+      const cursor = keyboard.xpathSelect('.//*[@bounds and contains(@uri, "cursor_textInput")]');
+      if (input && (cursor?.bounds?.x || keyboard.attributes.text)) {
+        for (let i = 0, n = input.text.length; i < n; i++) {
+          await this.sdk.ecp.keypress('Backspace');
+        }
+      }
+
+      return;
+    }
+
+    // Otherwise, we need to activate keyboard
+    // by selecting element and then removing text
+
+    await this.select();
+
+    keyboard = await this.document.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]', 5);
+
+    if (keyboard) {
+      await keyboard.clear();
+    } else {
+      throw new RokuError('Keyboard dialog did not appear after pressing `Select` on element');
+    }
+
+    // Submit changes by selecting the first button in the dialog
+    // or by sending `Enter` button
+
+    const submitButton = await keyboard.xpathSelect('./ancestor-or-self::*[self::Dialog or self::KeyboardDialog or self::PinDialog or self::ProgressDialog]//ButtonGroup');
+
+    if (submitButton) {
+      await submitButton.select();
+    } else {
+      await this.sdk.ecp.keypress('Enter');
+    }
+
+    // Wait for the keyboard to disappear
+
+    const isKeyboardClosed = !(await this.document.xpathSelect('self::*[not(./descendant-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad])]', 5));
+    if (isKeyboardClosed) {
+      throw new RokuError('Keyboard dialog did not disappear');
+    }
+  }
+
+  async type(text: string) {
+    // If the element is inside the keyboard,
+    // make sure the keyboard is activated
+    // and send the text
+
+    let keyboard = this.xpathSelect('./ancestor-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+
+    if (keyboard) {
+      if (text) {
+        await keyboard.focus();
+        await this.sdk.ecp.type(text);
+      }
+
+      return;
+    }
+
+    // Otherwise, we need to activate keyboard
+    // by selecting element and then send the text
+
+    await this.select();
+
+    keyboard = await this.document.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]', 5);
+
+    if (keyboard) {
+      await keyboard.type(text);
+    } else {
+      throw new RokuError('Keyboard dialog did not appear after pressing `Select` on element');
+    }
+
+    // Submit changes by selecting the first button in the dialog
+    // or by sending `Enter` button
+
+    const submitButton = await keyboard.xpathSelect('./ancestor-or-self::*[self::Dialog or self::KeyboardDialog or self::PinDialog or self::ProgressDialog]//ButtonGroup');
+
+    if (submitButton) {
+      await submitButton.select();
+    } else {
+      await this.sdk.ecp.keypress('Enter');
+    }
+
+    // Wait for the keyboard to disappear
+
+    const isKeyboardClosed = !(await this.document.xpathSelect('self::*[not(./descendant-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad])]', 5));
+    if (isKeyboardClosed) {
+      throw new RokuError('Keyboard dialog did not disappear');
+    }
+  }
+
   async select() {
     await this.focus();
     await this.sdk.ecp.keypress('Select');


### PR DESCRIPTION
Added ability to enter/remove text and check if keyboard is shown

___

Please note that `clear`/`type` function works differently depending on which element is used.

- **Document with keyboard**
      Adds/ Removes text.

- **Document without keyboard**
      `type` - sends each character from text.
      `clear` - throw an exception, because it does not know how many times to press` Backspace`.

- **Keyboard or elements within it**
       Adds/ Removes text.

- **Elements outside of keyboard**
        1. Presses `Select` after hovering given element.
        2. Waits "keyboard" to appear.
        3. Adds/ Removes text.
        4. Selects the first button from `Dialog` or presses `Enter` otherwise.
        5. Waits "keyboard" to disappear.

____

```typescript
get isKeyboardShown(): boolean
```

```typescript
clear(): Promise<void>
```

```typescript
type(text: string): Promise<void>
```
