### PR TITLE
fix(dom): return only visible text

### DIFF
--- a/src/Element.ts
+++ b/src/Element.ts
@@ -110,6 +110,7 @@ export class Element {
 
   get text(): string {
     return this.xpathSelectAll('./descendant-or-self::*[(self::Label or self::SimpleLabel) and @text]')
+      .filter((element) => element.isDisplayed)
       .map((element) => element.attributes.text.trim())
       .filter((text) => text)
       .join('\n');


### PR DESCRIPTION
Updated `element.text` to return only text from visible nodes with `Label`/`SimpleLabel` tag.