### PR TITLE
fix(debug-server): connectivity

### DIFF
--- a/packages/debug-server/package.json
+++ b/packages/debug-server/package.json
@@ -18,8 +18,5 @@
   },
   "engines": {
     "node": ">=12"
-  },
-  "dependencies": {
-    "telnet-client": "^1.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ const pkg = require(cwd + '/package.json');
 
 export default {
   input: cwd + '/src/index.ts',
-  external: Object.keys(pkg.dependencies),
+  external: Object.keys(pkg.dependencies || {}),
   output: [
     {
       file: cwd + '/' + pkg.main,


### PR DESCRIPTION
I decided to get rid of the `telnet-client` in favor of the `net` package, because currently the `debug-server` client does not need a persistent connection, and opening/closing telnet connections adds significant overhead and sometime fails unexpectedly.