### PR TITLE
fix(ecp): handle empty `params` object

### DIFF
--- a/packages/ecp/src/ECP.ts
+++ b/packages/ecp/src/ECP.ts
@@ -74,7 +74,7 @@ export class ECP {
   }
 
   private async ecp<T extends string | Buffer | void>(method: string, path: string, params?: Record<string, any>): Promise<T> {
-    if (params) {
+    if (params && Object.keys(params).length) {
       path += '?' + new URLSearchParams(params);
     }
 


### PR DESCRIPTION
Previously, the empty object `{}` was translated to `?`, but in this situation it should not be sent at all