### PR TITLE
feat(odc): allow serializable types in `patchRegistry`

### DIFF
--- a/packages/odc/README.md
+++ b/packages/odc/README.md
@@ -47,7 +47,7 @@ getRegistry(): Promise<Record<string, Record<string, string>>>
 ```
 
 ```typescript
-patchRegistry(changes: Record<string, null | Record<string, string | null>>): Promise<void>
+patchRegistry(changes: Record<string, null | Record<string, any>>): Promise<void>
 ```
 
 ```typescript

--- a/packages/odc/src/ODC.ts
+++ b/packages/odc/src/ODC.ts
@@ -22,7 +22,7 @@ export class ODC {
     return await this.request('GET', `registry`);
   }
 
-  async patchRegistry(changes: Record<string, null | Record<string, string | null>>): Promise<void> {
+  async patchRegistry(changes: Record<string, null | Record<string, any>>): Promise<void> {
     await this.request('PATCH', `registry`, changes);
   }
 

--- a/packages/odc/src/odc/commands/patchRegistry.brs
+++ b/packages/odc/src/odc/commands/patchRegistry.brs
@@ -13,7 +13,7 @@ function patchRegistry(request, response)
         if item.value = invalid then
           section.delete(item.key)
         else
-          section.write(item.key, item.value)
+          section.write(item.key, toString(item.value))
         end if
       end for
 

--- a/packages/odc/src/odc/source/odc_main.brs
+++ b/packages/odc/src/odc/source/odc_main.brs
@@ -20,7 +20,14 @@ sub odc_main(options as Object)
           if item.value = invalid then
             section.delete(item.key)
           else
-            section.write(item.key, item.value)
+            value = item.value
+            if getInterface(value, "ifToStr") = invalid then
+              value = formatJSON(value, 1)
+            else
+              value = box(value).toStr()
+            end if
+
+            section.write(item.key, value)
           end if
         end for
 


### PR DESCRIPTION
Only string values can be used in registry key value, but very often people put a json representation of data in it, to simplify this now the `patchRegistry` method will automatically convert the type to a string representation