### PR TITLE
fix(odc): main method patching in files with `\r`

### DIFF
--- a/packages/odc/src/odc/index.ts
+++ b/packages/odc/src/odc/index.ts
@@ -45,7 +45,7 @@ export default async function extend(app: Buffer): Promise<Buffer> {
 
   // patch entry points
   const pattern = /(\.show\(\))/i;
-  const entryPointMatcher = /(^\s*(sub|function)\s+(main|runuserinterface)\s*\()\s*([\w$%!#&]+)?\s*[^)]*(\)[^:\n]*)/gim;
+  const entryPointMatcher = /(^\s*(sub|function)\s+(main|runuserinterface)\s*\()\s*([\w$%!#&]+)?\s*[^)]*(\)[^:\r\n]*)/gim;
   for (const file of zip.file(/^source\/.*\.brs$/i)) {
     let source = await file.async('string');
     let content = source;


### PR DESCRIPTION
Tried to patch few channels from github and identified that there are people that uses `\r\n?` instead of `\n` for line delimiter