### PR TITLE
docs: remove prefix from `CHANGELOG.md`

### DIFF
--- a/packages/ecp/CHANGELOG.md
+++ b/packages/ecp/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* **ecp:** ability to send json ([172dec6](https://www.github.com/dlenroc/node-roku/commit/172dec6f2cbaca961b544fc1e87be5cec6afb1f9))
+* ability to send json ([172dec6](https://www.github.com/dlenroc/node-roku/commit/172dec6f2cbaca961b544fc1e87be5cec6afb1f9))
 
 ### [1.0.1](https://www.github.com/dlenroc/node-roku/compare/roku-ecp-v1.0.0...roku-ecp-v1.0.1) (2021-05-01)
 

--- a/packages/odc/CHANGELOG.md
+++ b/packages/odc/CHANGELOG.md
@@ -5,14 +5,14 @@
 
 ### Features
 
-* **odc:** ability to filter app-ui attributes ([ec0cc0d](https://www.github.com/dlenroc/node-roku/commit/ec0cc0d3a4cb17f4aed29e751b11b5176c54eaaf))
-* **odc:** allow serializable types in `patchRegistry` ([92074a1](https://www.github.com/dlenroc/node-roku/commit/92074a1bf8367423668dcdf45f05bc046215a9ea))
-* **odc:** fields with complex types in app-ui ([545a4ed](https://www.github.com/dlenroc/node-roku/commit/545a4ed34aec085ec87d2a01d0430bcc69967e49))
+* ability to filter app-ui attributes ([ec0cc0d](https://www.github.com/dlenroc/node-roku/commit/ec0cc0d3a4cb17f4aed29e751b11b5176c54eaaf))
+* allow serializable types in `patchRegistry` ([92074a1](https://www.github.com/dlenroc/node-roku/commit/92074a1bf8367423668dcdf45f05bc046215a9ea))
+* fields with complex types in app-ui ([545a4ed](https://www.github.com/dlenroc/node-roku/commit/545a4ed34aec085ec87d2a01d0430bcc69967e49))
 
 
 ### Bug Fixes
 
-* **odc:** main method patching in files with `\r` ([e3321ed](https://www.github.com/dlenroc/node-roku/commit/e3321ed83d70c7827a97bd6b9ab13dd61fa8b8d7))
+* main method patching in files with `\r` ([e3321ed](https://www.github.com/dlenroc/node-roku/commit/e3321ed83d70c7827a97bd6b9ab13dd61fa8b8d7))
 
 ## [1.1.0](https://www.github.com/dlenroc/node-roku/compare/roku-odc-v1.0.0...roku-odc-v1.1.0) (2021-05-01)
 


### PR DESCRIPTION
Removed package prefix from changelog entries