### PR TITLE
feat(odc): ability to list files using `getFiles`

### DIFF
--- a/packages/odc/README.md
+++ b/packages/odc/README.md
@@ -55,6 +55,10 @@ clearRegistry(): Promise<void>
 ```
 
 ```typescript
+getFiles(path: string): Promise<(File | Directory)[]>
+```
+
+```typescript
 pullFile(path: string): Promise<Buffer>
 ```
 

--- a/packages/odc/src/ODC.ts
+++ b/packages/odc/src/ODC.ts
@@ -3,6 +3,7 @@ import { URLSearchParams } from 'url';
 import extend from './internal/injector';
 import fetch from './internal/keep-alive-fetch';
 import { ODCError } from './ODCError';
+import { Directory, File } from './types';
 
 export class ODC {
   private readonly baseUrl: string;
@@ -29,6 +30,10 @@ export class ODC {
 
   async clearRegistry(): Promise<void> {
     await this.request('DELETE', `registry`);
+  }
+
+  async getFiles(path: string): Promise<(File | Directory)[]> {
+    return await this.request('GET', `files`, { path });
   }
 
   async pullFile(path: string): Promise<Buffer> {

--- a/packages/odc/src/odc/helpers/fs/getFiles.brs
+++ b/packages/odc/src/odc/helpers/fs/getFiles.brs
@@ -1,0 +1,26 @@
+
+function getFiles(root as string) as object
+  fs = CreateObject("roFileSystem")
+  files = fs.getDirectoryListing(root)
+  results = []
+
+  for i = 0 to files.count() - 1
+    path = root + "/" + files[i]
+    stat = fs.stat(path)
+    result = {
+      name: files[i],
+      type: stat.type,
+      permissions: stat.permissions
+    }
+
+    if stat.type = "file"
+      result.size = stat.size
+    else
+      result.children = getFiles(path)
+    end if
+
+    results.push(result)
+  end for
+
+  return results
+end function

--- a/packages/odc/src/odc/helpers/fs/makeDirs.brs
+++ b/packages/odc/src/odc/helpers/fs/makeDirs.brs
@@ -1,5 +1,5 @@
 
-function createDirectoryNested(path as string) as boolean
+function makeDirs(path as string) as boolean
   fs = CreateObject("roFileSystem")
   paths = []
 

--- a/packages/odc/src/odc/routes/onGetFiles.brs
+++ b/packages/odc/src/odc/routes/onGetFiles.brs
@@ -1,0 +1,6 @@
+' import '../helpers/fs/getFiles.brs'
+
+' @Route('GET', '/files')
+function onGetFiles(request as object, response as object) as object
+  return getFiles(request.search.path)
+end function

--- a/packages/odc/src/odc/routes/onPutFile.brs
+++ b/packages/odc/src/odc/routes/onPutFile.brs
@@ -1,4 +1,4 @@
-' import '../helpers/fs/createDirectoryNested.brs'
+' import '../helpers/fs/makeDirs.brs'
 ' import '../helpers/serialization/toByteArray.brs'
 
 ' @Route('PUT', '/file')
@@ -6,7 +6,7 @@ sub onPutFile(request as object, response as object)
   file = request.search.path
   folder = CreateObject("roPath", file).split().parent
 
-  folderExists = createDirectoryNested(folder)
+  folderExists = makeDirs(folder)
   if not folderExists
     response.code = 400
     response.body = { message: "path is invalid or not writable" }

--- a/packages/odc/src/odc/server.brs
+++ b/packages/odc/src/odc/server.brs
@@ -2,6 +2,7 @@
 ' import './routes/onDeleteRegistry.brs'
 ' import './routes/onGetAppUI.brs'
 ' import './routes/onGetFile.brs'
+' import './routes/onGetFiles.brs'
 ' import './routes/onGetRegistry.brs'
 ' import './routes/onPatchRegistry.brs'
 ' import './routes/onPutFile.brs'
@@ -16,6 +17,7 @@ sub start_server()
   server.addRoute("GET", "/app-ui", onGetAppUI)
   server.addRoute("GET", "/file", onGetFile)
   server.addRoute("PUT", "/file", onPutFile)
+  server.addRoute("GET", "/files", onGetFiles)
   server.addRoute("GET", "/registry", onGetRegistry)
   server.addRoute("PATCH", "/registry", onPatchRegistry)
   server.addRoute("DELETE", "/registry", onDeleteRegistry)

--- a/packages/odc/src/types/Directory.ts
+++ b/packages/odc/src/types/Directory.ts
@@ -1,0 +1,8 @@
+import { File } from './File';
+
+export interface Directory {
+  children: (File | Directory)[];
+  name: string;
+  permissions: 'r' | 'rw';
+  type: 'directory';
+}

--- a/packages/odc/src/types/File.ts
+++ b/packages/odc/src/types/File.ts
@@ -1,0 +1,6 @@
+export interface File {
+  name: string;
+  permissions: 'r' | 'rw';
+  size: number;
+  type: 'file';
+}

--- a/packages/odc/src/types/index.ts
+++ b/packages/odc/src/types/index.ts
@@ -1,0 +1,2 @@
+export { Directory } from './Directory';
+export { File } from './File';


### PR DESCRIPTION
I recently added the ability to receive and send any files to and from the roku device, but these methods require knowing the path that we are going to use, so now I add the ability to view files on disk for the case when we do not know the name of the file