### PR TITLE
fix(ecp): `queryApps` when there are no apps

### DIFF
--- a/packages/ecp/src/internal/xml.ts
+++ b/packages/ecp/src/internal/xml.ts
@@ -16,8 +16,10 @@ export default function parse(xml: string, options?: X2jOptionsOptional & { arra
   if (options?.array) {
     parsedXML = Object.values(parsedXML)[0];
 
-    if (parsedXML.length === 1) {
+    if (parsedXML) {
       parsedXML = Array.isArray(parsedXML) ? parsedXML : [parsedXML];
+    } else {
+      parsedXML = [];
     }
   }
 


### PR DESCRIPTION
Previously, an exception was thrown when no apps were installed on the device, but currently an empty array will be returned