### PR TITLE
fix(odc): exclusion of `bounds` and `focused` attributes

### DIFF
--- a/packages/odc/src/odc/helpers/serialization/toXML.brs
+++ b/packages/odc/src/odc/helpers/serialization/toXML.brs
@@ -9,62 +9,73 @@ function toXML(source as object, fields = invalid as object) as string
     fields: fields,
     render: sub(target as object, node as object)
       target = target.addElement(node.subtype())
-
-      if m.fields = invalid
-        for each field in node.items()
-          m.addField(target, node, field.key, field.value)
-        end for
-      else
-        fields = m.fields["*"]
-        if fields <> invalid then
-          for each field in fields
-            if node.doesExist(field) then
-              m.addField(target, node, field, node.getField(field))
-            end if
-          end for
-        end if
-
-        fields = m.fields[node.subtype()]
-        if fields <> invalid then
-          for each field in fields
-            if node.doesExist(field) then
-              m.addField(target, node, field, node.getField(field))
-            end if
-          end for
-        end if
-      end if
-
-      rect = node.sceneBoundingRect()
-      if rect.width <> 0 and rect.height <> 0 then
-        target.addAttribute("bounds", "[" + strI(rect.x).trim() + "," + strI(rect.y) + "," + strI(rect.width) + "," + strI(rect.height) + "]")
-      end if
-
-      isFocused = node.hasFocus()
-      if isFocused then
-        target.addAttribute("focused", node.hasFocus().toStr())
-      end if
-
-      if getInterface(node.dialog, "ifSGNodeChildren") <> invalid then
-        m.render(target, node.dialog)
-      end if
+      m.addFields(target, node)
 
       for each nested in node.getChildren(-1, 0)
         m.render(target, nested)
       end for
     end sub,
-    addField: sub(target as object, node as object, fieldKey as string, fieldValue as object)
-      if getInterface(fieldValue, "ifSGNodeField") <> invalid
-        fieldValue = fieldValue.getField("id")
+    addFields: sub(target as object, node as object)
+      includeBounds = true
+      includeFocused = true
+
+      if m.fields = invalid
+        for each key in node.keys()
+          m.addField(target, node, key)
+        end for
+      else
+        includeBounds = false
+        includeFocused = false
+
+        for each fields in [m.fields["*"], m.fields[node.subtype()]]
+          if fields <> invalid
+            for each field in fields
+              if node.doesExist(field)
+                m.addField(target, node, field)
+              else if field = "bounds"
+                includeBounds = true
+              else if field = "focused"
+                includeFocused = true
+              end if
+            end for
+          end if
+        end for
       end if
 
-      fieldValue = toSerializable(fieldValue)
+      if includeBounds
+        rect = node.sceneBoundingRect()
+        if rect.width <> 0 and rect.height <> 0
+          target.addAttribute("bounds", "[" + strI(rect.x).trim() + "," + strI(rect.y) + "," + strI(rect.width) + "," + strI(rect.height) + "]")
+        end if
+      end if
+
+      if includeFocused
+        isFocused = node.hasFocus()
+        if isFocused
+          target.addAttribute("focused", node.hasFocus().toStr())
+        end if
+      end if
+
+      if getInterface(node.dialog, "ifSGNodeChildren") <> invalid
+        m.render(target, node.dialog)
+      end if
+    end sub,
+    addField: sub(target as object, node as object, fieldKey as string)
+      fieldType = node.getFieldType(fieldKey)
+      fieldValue = node.getField(fieldKey)
+
       if fieldValue <> invalid
-        fieldType = node.getFieldType(fieldKey)
         if fieldType = "color"
           fieldValue = "#" + StrI(fieldValue, 16)
+        else if fieldType = "node"
+          fieldValue = fieldValue.getField("id")
+        else
+          fieldValue = toSerializable(fieldValue)
         end if
 
-        target.addAttribute(fieldKey, toString(fieldValue))
+        if fieldValue <> invalid
+          target.addAttribute(fieldKey, toString(fieldValue))
+        end if
       end if
     end sub
   }


### PR DESCRIPTION
Added the ability to exclude `bounds` / `focus` attributes from the app-ui representation