### PR TITLE
fix(dom): generic `keyboard` and `dialog` selectors

### DIFF
--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@dlenroc/roku": "^1.0.0",
-    "css-select": "^3.0.0",
+    "css-select": "^4.0.0",
     "css-select-base-adapter": "^0.1.1",
-    "libxmljs2": "^0.26.7"
+    "libxmljs2": "^0.27.0"
   }
 }

--- a/packages/dom/src/Document.ts
+++ b/packages/dom/src/Document.ts
@@ -21,11 +21,11 @@ export class Document extends Element {
   }
 
   get isKeyboardShown(): boolean {
-    return this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]')?.isDisplayed || false;
+    return this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]')?.isDisplayed || false;
   }
 
   async clear() {
-    const keyboard = this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
 
     if (keyboard) {
       await keyboard.clear();
@@ -35,7 +35,7 @@ export class Document extends Element {
   }
 
   async type(text: string) {
-    const keyboard = this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
 
     if (keyboard) {
       await keyboard.type(text);
@@ -45,7 +45,7 @@ export class Document extends Element {
   }
 
   async append(text: string) {
-    const keyboard = this.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
 
     if (keyboard) {
       await keyboard.append(text);

--- a/packages/dom/src/Element.ts
+++ b/packages/dom/src/Element.ts
@@ -328,7 +328,7 @@ async function appendOrSetText(element: Element, text: string, clear: boolean) {
   // make sure the keyboard is activated
   // and make changes to the text
 
-  let keyboard = element.xpathSelect('./ancestor-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad]');
+  let keyboard = element.xpathSelect('./ancestor-or-self::*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
 
   if (keyboard) {
     if (clear || text) {
@@ -357,7 +357,7 @@ async function appendOrSetText(element: Element, text: string, clear: boolean) {
 
   await element.select();
 
-  keyboard = await element.document.xpathSelect('//*[self::Keyboard or self::MiniKeyboard or self::PinPad]', 5);
+  keyboard = await element.document.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]', 5);
 
   if (keyboard) {
     await appendOrSetText(keyboard, text, clear);
@@ -368,7 +368,7 @@ async function appendOrSetText(element: Element, text: string, clear: boolean) {
   // Submit changes by selecting the first button in the dialog
   // or by sending `Enter` button
 
-  const submitButton = keyboard.xpathSelect('./ancestor-or-self::*[self::Dialog or self::KeyboardDialog or self::PinDialog or self::ProgressDialog]//ButtonGroup');
+  const submitButton = keyboard.xpathSelect('./ancestor-or-self::*[substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"]//ButtonGroup');
 
   if (submitButton) {
     await submitButton.select();
@@ -378,7 +378,7 @@ async function appendOrSetText(element: Element, text: string, clear: boolean) {
 
   // Wait for the keyboard to disappear
 
-  const isKeyboardClosed = !(await element.document.xpathSelect('self::*[not(./descendant-or-self::*[self::Keyboard or self::MiniKeyboard or self::PinPad])]', 5));
+  const isKeyboardClosed = !(await element.document.xpathSelect('self::*[not(./descendant-or-self::*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"])]', 5));
   if (isKeyboardClosed) {
     throw new RokuError('Keyboard dialog did not disappear');
   }


### PR DESCRIPTION
Updated dom to include more general selectors for keyboards and dialogs based on the component name suffix