### PR TITLE
fix(odc): handling whitespace in scene

### DIFF
--- a/packages/odc/src/internal/injector.ts
+++ b/packages/odc/src/internal/injector.ts
@@ -82,7 +82,7 @@ export default async function extend(app: Buffer): Promise<Buffer> {
   }
 
   // patch scenes
-  const isScenePattern = /<component .*extends="(Base)?Scene"/i;
+  const isScenePattern = /<component(\s+|\s+.*?\s+)extends\s*=\s*"(Base)?Scene"/i;
   const endSceneComponentPattern = /(<\/component>)/i;
   const endInterfaceComponentPattern = /(<\/interface>)/i;
   for (const file of zip.file(/^components\/.*\.xml$/i)) {


### PR DESCRIPTION
Some roku channels I used had spaces around `=` which broke `getAppUI` because client component was not injected in scene

An example of such a scene declaration
```xml
<component name = "KeyboardDialogExample" extends = "Scene" >
```
