### PR TITLE
fix(dom): handle `extends` attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
     "build": "npm run build -ws"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-typescript": "^8.3.0",
-    "@types/node": "^17.0.19",
+    "@rollup/plugin-node-resolve": "^13.2.1",
+    "@rollup/plugin-typescript": "^8.3.2",
+    "@types/node": "^17.0.25",
     "@types/node-fetch": "^2.6.1",
     "replace-in-file": "^6.3.2",
     "rimraf": "^3.0.2",
-    "rollup": "^2.67.3",
+    "rollup": "^2.70.2",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.6.3"
   },
   "engines": {
     "node": ">=12",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@dlenroc/roku": "^1.2.0",
-    "css-select": "^4.2.1",
+    "css-select": "^4.3.0",
     "css-select-base-adapter": "^0.1.1",
     "libxmljs2": "^0.29.0"
   }

--- a/packages/dom/src/Document.ts
+++ b/packages/dom/src/Document.ts
@@ -1,7 +1,8 @@
+import { SDK } from '@dlenroc/roku';
 import { Element as XMLElement, parseXml } from 'libxmljs2';
 import { Element } from './Element';
 import { RokuError } from './Error';
-import { SDK } from '@dlenroc/roku';
+import { KEYBOARD } from './internal/selectors';
 
 const rootXML = '<app-ui></app-ui>';
 const rootNode = parseXml(rootXML, { noblanks: true }).root() as XMLElement;
@@ -21,11 +22,11 @@ export class Document extends Element {
   }
 
   get isKeyboardShown(): boolean {
-    return this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]')?.isDisplayed || false;
+    return this.xpathSelect(`//*[${KEYBOARD}]`)?.isDisplayed || false;
   }
 
   async clear() {
-    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
+    const keyboard = this.xpathSelect(`//*[${KEYBOARD}]`);
 
     if (keyboard) {
       await keyboard.clear();
@@ -35,7 +36,7 @@ export class Document extends Element {
   }
 
   async type(text: string) {
-    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
+    const keyboard = this.xpathSelect(`//*[${KEYBOARD}]`);
 
     if (keyboard) {
       await keyboard.type(text);
@@ -45,7 +46,7 @@ export class Document extends Element {
   }
 
   async append(text: string) {
-    const keyboard = this.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
+    const keyboard = this.xpathSelect(`//*[${KEYBOARD}]`);
 
     if (keyboard) {
       await keyboard.append(text);

--- a/packages/dom/src/internal/selectors.ts
+++ b/packages/dom/src/internal/selectors.ts
@@ -1,0 +1,24 @@
+
+export const KEYBOARD =
+  'substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard"' +
+  ' or ' +
+  'substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"' +
+  ' or ' +
+  'substring(@extends, string-length(name()) - string-length("Keyboard") + 1) = "Keyboard"' +
+  ' or ' +
+  'substring(@extends, string-length(name()) - string-length("PinPad") + 1) = "PinPad"';
+
+export const DIALOG =
+  'substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"' +
+  ' or ' +
+  'substring(@extends, string-length(name()) - string-length("Dialog") + 1) = "Dialog"';
+
+export const BUTTON =
+  'substring(name(), string-length(name()) - string-length("Button") + 1) = "Button"' +
+  ' or ' +
+  'substring(@extends, string-length(name()) - string-length("Button") + 1) = "Button"';
+
+export const LABEL =
+  'substring(name(), string-length(name()) - string-length("Label") + 1) = "Label"' +
+  ' or ' +
+  'substring(@extends, string-length(name()) - string-length("Label") + 1) = "Label"';


### PR DESCRIPTION
Updated XPath selectors to take into account the `extends` attribute during element identification (this solution is far from final, but helps to cover more cases without major refactoring)