### PR TITLE
fix: ability to set custom port and abort commands

### DIFF
--- a/packages/debug-server/README.md
+++ b/packages/debug-server/README.md
@@ -13,7 +13,9 @@ npm install @dlenroc/roku-debug-server
 ```typescript
 import DebugServer from '@dlenroc/roku-debug-server';
 
-const debugServer = new DebugServer('<ip>');
+// const debugServer = new DebugServer('<ip>');
+const debugServer = new DebugServer({ address: 'tcp://<ip>:8080' });
+
 await debugServer.enableProfiling();
 ```
 

--- a/packages/debug-server/src/DebugServerOptions.ts
+++ b/packages/debug-server/src/DebugServerOptions.ts
@@ -1,0 +1,4 @@
+export type DebugServerOptions = {
+  address: string;
+  signal?: AbortSignal;
+}

--- a/packages/developer-server/README.md
+++ b/packages/developer-server/README.md
@@ -16,7 +16,9 @@ import DeveloperServer from '@dlenroc/roku';
 
 const app = fs.readFileSync('<path_to_channel>');
 
-const developerServer = new DeveloperServer('<ip>', '<username>', '<password>');
+// const developerServer = new DeveloperServer('<ip>', '<username>', '<password>');
+const developerServer = new DeveloperServer({ address: 'http://<ip>', username: '<username>', password: '<password>' });
+
 await developerServer.install(app);
 ```
 

--- a/packages/developer-server/package.json
+++ b/packages/developer-server/package.json
@@ -20,8 +20,8 @@
     "node": ">=12"
   },
   "dependencies": {
+    "digest-header": "^1.1.0",
     "form-data": "^4.0.0",
-    "indigestion": "^0.1.4",
     "node-fetch": "^2.6.7"
   }
 }

--- a/packages/developer-server/src/Agent.ts
+++ b/packages/developer-server/src/Agent.ts
@@ -1,0 +1,8 @@
+import http from 'http';
+import https from 'https';
+
+const options = { keepAlive: false };
+const httpAgent = new http.Agent(options);
+const httpsAgent = new https.Agent(options);
+
+export const agent = (url: URL) => (url.protocol === 'http:' ? httpAgent : httpsAgent);

--- a/packages/developer-server/src/DeveloperServerOptions.ts
+++ b/packages/developer-server/src/DeveloperServerOptions.ts
@@ -1,0 +1,6 @@
+export type DeveloperServerOptions = {
+  address: string;
+  username: string;
+  password: string;
+  signal?: AbortSignal;
+}

--- a/packages/ecp/README.md
+++ b/packages/ecp/README.md
@@ -13,7 +13,9 @@ npm install @dlenroc/roku-ecp
 ```typescript
 import ECP from '@dlenroc/roku';
 
-const ecp = new ECP('<ip>');
+// const ecp = new ECP('<ip>');
+const ecp = new ECP({ address: 'http://<ip>:8060' });
+
 const xml = await ecp.queryAppUI();
 
 console.log(xml);

--- a/packages/ecp/src/ECP.ts
+++ b/packages/ecp/src/ECP.ts
@@ -1,14 +1,19 @@
 import { URLSearchParams } from 'url';
 import { ECPError } from './ECPError';
+import type { ECPOptions } from './ECPOptions';
 import fetch from './internal/keep-alive-fetch';
 import parse from './internal/xml';
 import { ActiveApp, App, AppId, ChannelPerformance, DeviceInfo, FWBeacons, FWBeaconsStatus, Failure, GraphicsFrameRate, Key, MediaInfo, Params, R2D2Bitmaps, Registry, SGRendezvousStatus } from './types';
 
 export class ECP {
-  private readonly baseUrl: string;
+  private readonly config: ECPOptions;
 
-  constructor(ip: string) {
-    this.baseUrl = `http://${ip}:8060`;
+  constructor(ip: string)
+  constructor(options: ECPOptions)
+  constructor(ipOrOptions: string | ECPOptions) {
+    this.config = typeof ipOrOptions === 'string'
+      ? { address: `http://${ipOrOptions}:8060` }
+      : ipOrOptions;
   }
 
   async queryAppUI(): Promise<string> {
@@ -145,7 +150,7 @@ export class ECP {
       path += '?' + new URLSearchParams(params);
     }
 
-    const response = await fetch(this.baseUrl + '/' + path, { method });
+    const response = await fetch(this.config.address + '/' + path, { method, signal: this.config.signal });
 
     if (!response.ok) {
       throw new ECPError(`${method} /${path} -> ${response.status} ${response.statusText}`);

--- a/packages/ecp/src/ECPOptions.ts
+++ b/packages/ecp/src/ECPOptions.ts
@@ -1,0 +1,4 @@
+export type ECPOptions = {
+  address: string;
+  signal?: AbortSignal;
+}

--- a/packages/odc/README.md
+++ b/packages/odc/README.md
@@ -16,17 +16,13 @@ npm install @dlenroc/roku-odc
 import fs from 'fs';
 import SDK, { DeveloperServer, ODC } from '@dlenroc/roku';
 
+// const odc = new ODC('<ip>');
+const odc = new ODC({ address: 'http://<ip>:8061' });
+
+// const developerServer = new DeveloperServer('<ip>', '<username>', '<password>');
+const developerServer = new DeveloperServer({ address: 'http://<ip>', username: '<username>', password: '<password>' });
+
 const app = fs.readFileSync('<path_to_channel>');
-
-// SDK
-const sdk = new SDK('<ip>', '<username>', '<password>');
-const patchedApp = await sdk.odc.extend(app);
-await sdk.developerServer.install(patchedApp);
-await sdk.odc.getRegistry();
-
-// ODC
-const odc = new ODC('<ip>');
-const developerServer = new DeveloperServer('<ip>', '<username>', '<password>');
 const patchedApp = await odc.extend(app);
 await developerServer.install(patchedApp);
 await odc.getRegistry();

--- a/packages/odc/src/ODC.ts
+++ b/packages/odc/src/ODC.ts
@@ -1,15 +1,20 @@
 import { BodyInit } from 'node-fetch';
 import { URLSearchParams } from 'url';
+import { ODCError } from './ODCError';
+import type { ODCOptions } from './ODCOptions';
 import extend from './internal/injector';
 import fetch from './internal/keep-alive-fetch';
-import { ODCError } from './ODCError';
 import { Directory, File } from './types';
 
 export class ODC {
-  private readonly baseUrl: string;
+  private readonly config: ODCOptions;
 
-  constructor(ip: string) {
-    this.baseUrl = `http://${ip}:8061`;
+  constructor(ip: string)
+  constructor(options: ODCOptions)
+  constructor(ipOrOptions: string | ODCOptions) {
+    this.config = typeof ipOrOptions === 'string'
+      ? { address: `http://${ipOrOptions}:8061` }
+      : ipOrOptions;
   }
 
   async extend(app: Buffer): Promise<Buffer> {
@@ -68,7 +73,7 @@ export class ODC {
       }
     }
 
-    const response = await fetch(this.baseUrl + '/' + path, { method, headers, body });
+    const response = await fetch(this.config.address + '/' + path, { method, headers, body, signal: this.config.signal });
 
     if (!response.ok) {
       const json = await response.json();

--- a/packages/odc/src/ODCOptions.ts
+++ b/packages/odc/src/ODCOptions.ts
@@ -1,0 +1,4 @@
+export type ODCOptions = {
+  address: string;
+  signal?: AbortSignal;
+}


### PR DESCRIPTION
Added the ability to set custom ports using configuration objects and abort all commands running on a specific instance using AbortSignal.

I also noticed that `developer-server` stopped working due to the fact that in the Node.js 20 `keep-alive` parameter became `true`, which is not yet supported by the roku server, so I turned it off by default.