### PR TITLE
chore(ecp): fix `fast-xml-parser` import

### DIFF
--- a/packages/ecp/src/internal/xml.ts
+++ b/packages/ecp/src/internal/xml.ts
@@ -1,4 +1,4 @@
-import { XMLParser, type X2jOptionsOptional } from 'fast-xml-parser';
+import { XMLParser, type X2jOptions } from 'fast-xml-parser';
 
 const globalOptions = {
   attributeNamePrefix: '',
@@ -9,7 +9,7 @@ const globalOptions = {
 
 export default function parse(
   xml: string,
-  options?: X2jOptionsOptional & { array?: boolean }
+  options?: X2jOptions & { array?: boolean }
 ): any {
   let parsedXML = new XMLParser({ ...globalOptions, ...options }).parse(xml);
 


### PR DESCRIPTION
As part of https://github.com/NaturalIntelligence/fast-xml-parser/pull/580, a breaking change in exported types has been introduced without incrementing the major version. In this PR, I've updated the imported type to ensure the project compiles with the latest version of fast-xml-parser.