### PR TITLE
fix: associative array serialization

### DIFF
--- a/packages/odc/src/odc/helpers/serialization/toSerializable.brs
+++ b/packages/odc/src/odc/helpers/serialization/toSerializable.brs
@@ -17,7 +17,15 @@ function toSerializable(source as object) as object
   if getInterface(source, "ifAssociativeArray") <> invalid
     result = {}
 
-    for each item in source.items()
+    if source.ifAssociativeArray = invalid
+      items = source.ifAssociativeArray.items()
+    else if source.items = invalid
+      items = source.items()
+    else
+      items = []
+    end if
+
+    for each item in items
       value = item.value
 
       if getInterface(value, "ifSGNodeField") <> invalid


### PR DESCRIPTION
Update the `toSerializable` helper to be able to serialize objects that contain either `items` or `ifAssociativeArray`, but not both so far.

```sh
Brightscript Debugger> ?formatJSON(odc_toSerializable({ items: 1, extra: 1 }))
{"extra":1,"items": 1}

Brightscript Debugger> ?formatJSON(odc_toSerializable({ ifAssociativeArray: 1, extra: 1 }))
{"extra":1,"ifassociativearray": 1}

Brightscript Debugger> ?formatJSON(odc_toSerializable({ items: 1, ifAssociativeArray: 1, extra: 1 }))
{}
```